### PR TITLE
Send metrics from snap agent to Influxdb

### DIFF
--- a/workloads/common/analysis-base.json
+++ b/workloads/common/analysis-base.json
@@ -10,6 +10,10 @@
         {
             "task": "benchmark-agent",
             "id": 2
+        },
+        {
+            "task": "snap-agent",
+            "id": 2
         }
     ],
     "clusterDefinition": {
@@ -106,6 +110,130 @@
                     1
                 ],
                 "family": "benchmark-agent"
+            },
+            {
+                "deployment": {
+                    "apiVersion": "extensions\/v1beta1",
+                    "kind": "Deployment",
+                    "metadata": {
+                        "labels": {
+                            "app": "snap-agent",
+                            "version": "latest"
+                        },
+                        "name": "snap-agent"
+                    },
+                    "spec": {
+                        "replicas": 1,
+                        "selector": {
+                            "matchLabels": {
+                                "app": "snap-agent",
+                                "version": "latest"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "labels": {
+                                    "app": "snap-agent",
+                                    "version": "latest"
+                                }
+                            },
+                            "spec": {
+                                "containers": [
+                                    {
+                                        "image": "hyperpilot\/snap:alpine-init_dev",
+                                        "name": "snap-agent",
+                                        "command": [
+                                            "\/usr\/local\/bin\/run.sh"
+                                        ],
+                                        "args": [
+                                            "https:\/\/s3.amazonaws.com\/hyperpilot-snap-collectors\/snap-agent-init.json"
+                                        ],
+                                        "resources": {},
+                                        "imagePullPolicy": "Always",
+                                        "securityContext": {
+                                            "privileged": true
+                                        },
+                                        "volumeMounts": [
+                                            {
+                                                "mountPath": "\/var\/run",
+                                                "name": "var-run"
+                                            },
+                                            {
+                                                "mountPath": "\/var\/log",
+                                                "name": "var-log"
+                                            },
+                                            {
+                                                "mountPath": "\/sys\/fs\/cgroup",
+                                                "name": "cgroup"
+                                            },
+                                            {
+                                                "mountPath": "\/var\/lib\/docker",
+                                                "name": "var-lib-docker"
+                                            },
+                                            {
+                                                "mountPath": "\/usr\/local\/bin\/docker",
+                                                "name": "usr-bin-docker"
+                                            },
+                                            {
+                                                "mountPath": "\/proc_host",
+                                                "name": "proc"
+                                            }
+                                        ],
+                                        "env": [
+                                            {
+                                                "name": "NODE_NAME",
+                                                "valueFrom": {
+                                                    "fieldRef": {
+                                                        "fieldPath": "spec.nodeName"
+                                                    }
+                                                }
+                                            }
+                                        ]
+                                    }
+                                ],
+                                "volumes": [
+                                    {
+                                        "hostPath": {
+                                            "path": "\/sys\/fs\/cgroup"
+                                        },
+                                        "name": "cgroup"
+                                    },
+                                    {
+                                        "hostPath": {
+                                            "path": "\/var\/lib\/docker\/"
+                                        },
+                                        "name": "var-lib-docker"
+                                    },
+                                    {
+                                        "hostPath": {
+                                            "path": "\/var\/log"
+                                        },
+                                        "name": "var-log"
+                                    },
+                                    {
+                                        "hostPath": {
+                                            "path": "\/var\/run"
+                                        },
+                                        "name": "var-run"
+                                    },
+                                    {
+                                        "hostPath": {
+                                            "path": "\/usr\/bin\/docker"
+                                        },
+                                        "name": "usr-bin-docker"
+                                    },
+                                    {
+                                        "hostPath": {
+                                            "path": "\/proc"
+                                        },
+                                        "name": "proc"
+                                    }
+                                ]
+                            }
+                        }
+                    }
+                },
+                "family": "snap-agent"
             }
         ]
     }

--- a/workloads/in-cluster/deploy-k8s.json
+++ b/workloads/in-cluster/deploy-k8s.json
@@ -1,4 +1,4 @@
- {
+{
     "name": "in-cluster",
     "region": "us-east-1",
     "nodeMapping": [
@@ -16,6 +16,10 @@
         },
         {
             "task": "mongo-serve",
+            "id": 1
+        },
+        {
+            "task": "influxdb",
             "id": 1
         }
     ],
@@ -222,8 +226,12 @@
                                             }
                                         ],
                                         "image": "mongo:3.4",
-                                        "command": ["mongod"],
-                                        "args": ["-auth"],
+                                        "command": [
+                                            "mongod"
+                                        ],
+                                        "args": [
+                                            "-auth"
+                                        ],
                                         "name": "mongo-serve",
                                         "ports": [
                                             {
@@ -301,6 +309,89 @@
                     0
                 ],
                 "family": "analyzer"
+            },
+            {
+                "deployment": {
+                    "apiVersion": "extensions\/v1beta1",
+                    "kind": "Deployment",
+                    "metadata": {
+                        "labels": {
+                            "app": "influxdb"
+                        },
+                        "name": "influxdb",
+                        "namespace": "hyperpilot"
+                    },
+                    "spec": {
+                        "replicas": 1,
+                        "template": {
+                            "metadata": {
+                                "labels": {
+                                    "app": "influxdb"
+                                }
+                            },
+                            "spec": {
+                                "hostname": "influxdb",
+                                "volumes": [
+                                    {
+                                        "hostPath": {
+                                            "path": "\/home\/ubuntu\/influx_data"
+                                        },
+                                        "name": "influx-data"
+                                    }
+                                ],
+                                "containers": [
+                                    {
+                                        "env": [
+                                            {
+                                                "name": "ADMIN_USER",
+                                                "value": "root"
+                                            },
+                                            {
+                                                "name": "PRE_CREATE_DB",
+                                                "value": "snap"
+                                            },
+                                            {
+                                                "name": "INFLUXDB_INIT_PWD",
+                                                "value": "default"
+                                            }
+                                        ],
+                                        "image": "hyperpilot\/influx:1.2.2.a",
+                                        "name": "influxdb",
+                                        "ports": [
+                                            {
+                                                "containerPort": 8083,
+                                                "hostPort": 8083,
+                                                "protocol": "TCP"
+                                            },
+                                            {
+                                                "containerPort": 8086,
+                                                "hostPort": 8086,
+                                                "protocol": "TCP"
+                                            }
+                                        ],
+                                        "volumeMounts": [
+                                            {
+                                                "mountPath": "\/var\/lib\/influxdb",
+                                                "name": "influx-data"
+                                            }
+                                        ],
+                                        "resources": {
+                                            "requests": {
+                                                "cpu": "2048m",
+                                                "memory": "4096Mi"
+                                            }
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    }
+                },
+                "family": "influxdb",
+                "portTypes": [
+                    1,
+                    1
+                ]
             }
         ]
     }


### PR DESCRIPTION
# WHAT / WHY

* Collect metrics from every EC2 machine and send them to influxdb

# Result

<img width="1217" alt="screen shot 2017-08-09 at 01 22 19" src="https://user-images.githubusercontent.com/19871921/29112121-b30687ee-7ca1-11e7-9edd-1a131ebb23b6.png">


# TODO

* [x] Store metrics in an unique db every deployment.